### PR TITLE
Added support for material & texture exports

### DIFF
--- a/Datas/MaterialData.cs
+++ b/Datas/MaterialData.cs
@@ -10,14 +10,14 @@ namespace wackydatabase.Datas
         public string Name;
         public string Original;
         public bool Overwrite = false;
-        public MaterialData Changes;
+        public MaterialData Changes = new MaterialData();
     }
 
     [Serializable]
     public class MaterialData
     {
-        public Dictionary<string, Color> Colors;
-        public Dictionary<string, float> Floats;
-        public Dictionary<string, string> Textures;
+        public Dictionary<string, Color> Colors = new Dictionary<string, Color>();
+        public Dictionary<string, float> Floats = new Dictionary<string, float>();
+        public Dictionary<string, string> Textures = new Dictionary<string, string>();
     }
 }

--- a/GetData/YamlLoader.cs
+++ b/GetData/YamlLoader.cs
@@ -3,11 +3,13 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
 
 namespace wackydatabase.Datas {
     public class YamlLoader
     {
         private IDeserializer _deserializer;
+        private ISerializer _serializer;
         private StringBuilder _stringBuilder;
 
         public YamlLoader()
@@ -17,6 +19,13 @@ namespace wackydatabase.Datas {
                 .WithTypeConverter(new ValheimTimeConverter())
                 .IgnoreUnmatchedProperties() // future proofing
                 .Build();
+
+            _serializer = new SerializerBuilder()
+                .WithNamingConvention(CamelCaseNamingConvention.Instance)
+                .WithTypeConverter(new ColorConverter())
+                .WithTypeConverter(new ValheimTimeConverter())
+                .Build();
+
             _stringBuilder = new StringBuilder();
         }
 
@@ -48,13 +57,26 @@ namespace wackydatabase.Datas {
             return false;
         }
 
+        public bool Write<T>(string file, T data)
+        {
+            try
+            {
+                var fileContents = _serializer.Serialize(data);
+
+                File.WriteAllText(file, fileContents);
+
+                return true;
+            } catch (Exception ex)
+            {
+                WMRecipeCust.WLog.LogError(ex.Message);
+            }
+
+            return false;
+        }
+
         public override string ToString()
         {
             return _stringBuilder.ToString();
         }
-
-
-
-
     }
 }

--- a/Visuals/DataManagers/TextureDataManager.cs
+++ b/Visuals/DataManagers/TextureDataManager.cs
@@ -21,6 +21,15 @@ namespace wackydatabase
             File.WriteAllBytes(Path.Combine(WMRecipeCust.assetPathTextures, name + ".png"), data);
         }
 
+        public static void SaveTexture(string name, Texture t)
+        {
+            var clone = Colour.CloneTexture(t as Texture2D);
+
+            byte[] data = clone.EncodeToPNG();
+
+            File.WriteAllBytes(Path.Combine(WMRecipeCust.assetPathTextures, name + ".png"), data);
+        }
+
         public static Texture2D LoadTexture(string name)
         {
             string path = Path.Combine(WMRecipeCust.assetPathTextures, name + ".png");


### PR DESCRIPTION
Materials can now be exported with wackydb_save_material. This will create a new material based on the material provided, it comes predefined with all of the properties and their default values.

Textures that exist on an exported material will have an image file created in config/wackysDatabase/Textures for that texture.