### PR TITLE
Fixes for the wackydb_save_material command

### DIFF
--- a/PatchClasses/console.cs
+++ b/PatchClasses/console.cs
@@ -1162,17 +1162,26 @@ namespace wackydatabase.PatchClasses
 
             Terminal.ConsoleCommand WackySaveMaterial = new("wackydb_save_material", "Export default material settings for a material", args =>
             {
-                string name = args[1];
-                string clonedName = PrefabAssistant.SaveMaterial(name);
-
-                if (clonedName != null)
+                if (args.Length - 1 < 1)
                 {
-                    args.Context?.AddString($"Saved in the Material folder, as {clonedName}.yml");
-                } else
-                {
-                    args.Context?.AddString($"Material '{name}' not found.");
+                    args.Context?.AddString("<color=red>Not enough arguments</color>");
+                    return;
                 }
-            }, isCheat: false, isNetwork: false, onlyServer: false, isSecret: false, allowInDevBuild: false, () => (!ZNetScene.instance) ? new List<string>() : ZNetScene.instance.GetPrefabNames());
+                else
+                {
+                    string name = args[1];
+                    string clonedName = PrefabAssistant.SaveMaterial(name);
+
+                    if (clonedName != null)
+                    {
+                        args.Context?.AddString($"Saved in the Material folder, as {clonedName}.yml");
+                    }
+                    else
+                    {
+                        args.Context?.AddString($"Material '{name}' not found.");
+                    }
+                }
+            }, isCheat: false, isNetwork: false, onlyServer: false, isSecret: false, allowInDevBuild: false);
         }
     }
 }


### PR DESCRIPTION
Check for enough arguments and removed the prefab list options, which can and will replace the correct string.
A possible future upgrade is to fetch a list of names from Materials.txt, possibly without dupes and (instance) entries

Solves points 1 and 2 from #19.

I'll try to see if I can do anything about the remaining issues, but I don't really know much about Valheim modding.