### PR TITLE
Enables textures to retain the FilterMode property

### DIFF
--- a/Datas/MaterialData.cs
+++ b/Datas/MaterialData.cs
@@ -18,6 +18,6 @@ namespace wackydatabase.Datas
     {
         public Dictionary<string, Color> colors = new Dictionary<string, Color>();
         public Dictionary<string, float> floats = new Dictionary<string, float>();
-        public Dictionary<string, string> textures = new Dictionary<string, string>();
+        public Dictionary<string, Texture2D> textures = new Dictionary<string, Texture2D>();
     }
 }

--- a/GetData/Converters/TextureConverter.cs
+++ b/GetData/Converters/TextureConverter.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.CodeDom;
+using System.Collections.Generic;
+using System.Globalization;
+using TMPro;
+using UnityEngine;
+using YamlDotNet.Core;
+using YamlDotNet.Core.Events;
+using YamlDotNet.Serialization;
+
+namespace wackydatabase.Datas
+{
+    public class TextureConverter : IYamlTypeConverter
+    {
+        public bool Accepts(Type type)
+        {
+            return type == typeof(Texture2D);
+        }
+
+        public object ReadYaml(IParser parser, Type type)
+        {
+            string texture_name = null;
+            FilterMode texture_filterMode = FilterMode.Point;
+
+            if (parser.TryConsume<MappingStart>(out var mappingStart))
+            {
+
+                while (!parser.TryConsume<MappingEnd>(out var _))
+                {
+                    var key = parser.Consume<Scalar>().Value;
+                    var value = parser.Consume<Scalar>().Value;
+
+                    switch (key)
+                    {
+                        case "name": texture_name = value; break;
+                        case "filterMode": Enum.TryParse(value, out texture_filterMode); break;
+                    }
+
+                }
+            }
+            else
+            {
+                // single value with texture name
+                texture_name = parser.Consume<Scalar>().Value;
+            }
+
+            Texture2D t = TextureDataManager.LoadTexture(texture_name);
+            if (t != null)
+            {
+                t.name = texture_name;
+                t.filterMode = texture_filterMode;
+            }
+            else
+            { 
+                WMRecipeCust.WLog.LogInfo("Texture '" + texture_name + "' not found"); 
+            }
+            
+
+            return t;
+        }
+
+        public void WriteYaml(IEmitter emitter, object value, Type type)
+        {
+            Texture2D t = (Texture2D)value;
+            if (t.filterMode == FilterMode.Point)
+            { 
+                // single value style to keep it short (Point is the default)
+                emitter.Emit(new Scalar(t.name));
+            }
+            else
+            {
+                // multivalue style
+                emitter.Emit(new MappingStart(null, null, false, MappingStyle.Block));
+                emitter.Emit(new Scalar("name"));
+                emitter.Emit(new Scalar(t.name));
+                emitter.Emit(new Scalar("filterMode"));
+                emitter.Emit(new Scalar(t.filterMode.ToString()));
+                emitter.Emit(new MappingEnd());
+            }
+        }
+    }
+}

--- a/GetData/YamlLoader.cs
+++ b/GetData/YamlLoader.cs
@@ -16,6 +16,7 @@ namespace wackydatabase.Datas {
         {
             _deserializer = new DeserializerBuilder()
                 .WithTypeConverter(new ColorConverter())
+                .WithTypeConverter(new TextureConverter())
                 .WithTypeConverter(new ValheimTimeConverter())
                 .IgnoreUnmatchedProperties() // future proofing
                 .Build();
@@ -23,6 +24,7 @@ namespace wackydatabase.Datas {
             _serializer = new SerializerBuilder()
                 .WithNamingConvention(CamelCaseNamingConvention.Instance)
                 .WithTypeConverter(new ColorConverter())
+                .WithTypeConverter(new TextureConverter())
                 .WithTypeConverter(new ValheimTimeConverter())
                 .Build();
 

--- a/PatchClasses/console.cs
+++ b/PatchClasses/console.cs
@@ -1028,7 +1028,7 @@ namespace wackydatabase.PatchClasses
                                                 {
                                                     if (t != null)
                                                     {
-                                                        mi.changes.textures.Add(propertyName, t.name);
+                                                        mi.changes.textures.Add(propertyName, (Texture2D) t);
                                                         TextureDataManager.SaveTexture(t.name, t);
                                                     }
                                                 }

--- a/SetData/reload.cs
+++ b/SetData/reload.cs
@@ -107,6 +107,7 @@ namespace wackydatabase.SetData
 
                     var deserializer = new DeserializerBuilder()
                         .WithTypeConverter(new ColorConverter())
+                        .WithTypeConverter(new TextureConverter())
                         .WithTypeConverter(new ValheimTimeConverter())
                         .IgnoreUnmatchedProperties() // future proofing
                         .Build(); // make sure to include all

--- a/Visuals/DataManagers/DataManager.cs
+++ b/Visuals/DataManagers/DataManager.cs
@@ -20,6 +20,7 @@ namespace wackydatabase
     public abstract class DataManager<T>
     {
         protected static readonly ColorConverter cc = new ColorConverter();
+        protected static readonly TextureConverter tc = new TextureConverter();
         protected static readonly ValheimTimeConverter vtc = new ValheimTimeConverter();
 
         protected FileSystemWatcher fileSystemWatcher;
@@ -27,12 +28,14 @@ namespace wackydatabase
         public static readonly ISerializer Serializer = new SerializerBuilder()
             .WithNamingConvention(CamelCaseNamingConvention.Instance)
             .WithTypeConverter(cc)
+            .WithTypeConverter(tc)
             .WithTypeConverter(vtc)
             .Build();
 
         public static readonly IDeserializer Deserializer = new DeserializerBuilder()
             .WithNamingConvention(CamelCaseNamingConvention.Instance)
             .WithTypeConverter(cc)
+            .WithTypeConverter(tc)
             .WithTypeConverter(vtc)
             .Build();
 

--- a/Visuals/DataManagers/TextureDataManager.cs
+++ b/Visuals/DataManagers/TextureDataManager.cs
@@ -58,13 +58,13 @@ namespace wackydatabase
             return textureCache[name];
         }
 
-        public static Dictionary<string, Texture2D> GetTextures(Dictionary<string, string> textures)
+        public static Dictionary<string, Texture2D> GetTextures(Dictionary<string, Texture2D> textures)
         {
             Dictionary<string, Texture2D> data = new Dictionary<string, Texture2D>();
 
-            foreach (KeyValuePair<string, string> entry in textures)
+            foreach (KeyValuePair<string, Texture2D> entry in textures)
             {
-                data[entry.Key] = GetTexture(entry.Value);
+                data[entry.Key] = entry.Value;
             }
 
             return data;

--- a/Visuals/Materials/MaterialManipulator.cs
+++ b/Visuals/Materials/MaterialManipulator.cs
@@ -45,7 +45,7 @@ namespace wackydatabase
 
         public void ForceTextures(MaterialData data)
         {
-            foreach (KeyValuePair<string, string> entry in data.textures)
+            foreach (KeyValuePair<string, Texture2D> entry in data.textures)
             {
                 AddValue(new MaterialTextureEffect(entry.Key, TextureDataManager.GetTexture(entry.Key)));
             }

--- a/Visuals/PrefabAssistant.cs
+++ b/Visuals/PrefabAssistant.cs
@@ -166,7 +166,7 @@ namespace wackydatabase
                         {
                             if (t != null)
                             {
-                                mi.changes.textures.Add(propertyName, t.name);
+                                mi.changes.textures.Add(propertyName, (Texture2D) t);
                                 TextureDataManager.SaveTexture(t.name, t);
                             }
                         }

--- a/WackysRecipeCustomization.csproj
+++ b/WackysRecipeCustomization.csproj
@@ -144,6 +144,7 @@
     <Compile Include="Datas\StatusData.cs" />
     <Compile Include="Datas\TextureData.cs" />
     <Compile Include="Datas\ValheimTime.cs" />
+    <Compile Include="GetData\Converters\TextureConverter.cs" />
     <Compile Include="GetData\GetDataYML.cs" />
     <Compile Include="GetData\GetDataOld\GetData.cs" />
     <Compile Include="GetData\YamlLoader.cs" />


### PR DESCRIPTION
cc @Rexabit 

This PR adds the ability to save the sampling filter for each texture.
I kept the short form for the most common case of FilterMode.Point (nearest neighbor), but if you guys decide otherwise you can remove the single case from WriteYaml() in TextureConverter.

In short, there are now two forms to specify a texture:

The old form, which now implictly assumes filterMode: Point:
```
_MainTex: Oven_d
```

And the extended one:
```
    _MainTex:
      name: Oven_d
      filterMode: Trilinear
```
filterMode can also be a number, I used an enum tryparse so it works for both Point/Bilinear/Trilinear and 0/1/2